### PR TITLE
Fix building on windows with clang and msvc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ if(DEFINED NBT_DEST_DIR)
 endif()
 
 if(NBT_USE_ZLIB)
-    target_link_libraries(${NBT_NAME} z)
+    target_link_libraries(${NBT_NAME} ZLIB::ZLIB)
 endif()
 set_property(TARGET ${NBT_NAME} PROPERTY CXX_STANDARD 11)
 generate_export_header(${NBT_NAME} BASE_NAME nbt)

--- a/include/io/stream_writer.h
+++ b/include/io/stream_writer.h
@@ -23,6 +23,7 @@
 #include "tag.h"
 #include "endian_str.h"
 #include <iosfwd>
+#include <string>
 
 namespace nbt
 {

--- a/include/tag_array.h
+++ b/include/tag_array.h
@@ -126,11 +126,6 @@ typedef tag_array<int8_t> tag_byte_array;
 typedef tag_array<int32_t> tag_int_array;
 typedef tag_array<int64_t> tag_long_array;
 
-//Explicit instantiations
-template class NBT_EXPORT tag_array<int8_t>;
-template class NBT_EXPORT tag_array<int32_t>;
-template class NBT_EXPORT tag_array<int64_t>;
-
 }
 
 #endif // TAG_ARRAY_H_INCLUDED

--- a/include/tag_list.h
+++ b/include/tag_list.h
@@ -215,7 +215,7 @@ void tag_list::init(std::initializer_list<Arg> init)
     el_type_ = T::type;
     tags.reserve(init.size());
     for(const Arg& arg: init)
-        tags.emplace_back(make_unique<T>(arg));
+        tags.emplace_back(nbt::make_unique<T>(arg));
 }
 
 }

--- a/src/tag_array.cpp
+++ b/src/tag_array.cpp
@@ -126,4 +126,9 @@ void tag_array<int64_t>::write_payload(io::stream_writer& writer) const
         writer.write_num(i);
 }
 
+//Explicit instantiations
+template class NBT_EXPORT tag_array<int8_t>;
+template class NBT_EXPORT tag_array<int32_t>;
+template class NBT_EXPORT tag_array<int64_t>;
+
 }


### PR DESCRIPTION
These changes allow the library to be built on windows with clang and msvc.

I know those are not supported compilers but the changes still compile just fine with gcc on linux.

**tag_list.h**

added nbt namespace to avoid ambiguity with std::make_shared

**stream_writer**

stimple \<string> header include

**tag_array.h|cpp**

moved templated instantiations from the header to the bottom of the cpp file (clang complained that we were specializing before instantiation)

**CMakeLists.txt**

Added the correct name for linking ZLib

